### PR TITLE
Content Type for scand logs needs to be text/plain

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,6 +215,6 @@ func jobLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "text/plain")
 	w.Write(buf.Bytes())
 }


### PR DESCRIPTION
reverting accidental change for scand logs format.