### PR TITLE
Container Config addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ spec:
 
 ### Optionally configure POD rules
 
-Scan Jobs Manager can be configured to specify pod affinity or imagePullSecrets for the jobs it creates.
+Scand Manager can be configured to specify pod affinity, securityContext, resources, or imagePullSecrets for the jobs it creates.
 
 These can be specified by providing optional command line argument `-podconfig` poinining to `.yaml` or `.yml` file that describes affinity, similar to:
 
@@ -140,11 +140,30 @@ imagePullSecrets:
 ```
 See the docs for [`imagePullSecrets` key here](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)
 
+Launched scand-agent container restrictions can also be supplied
+
+```yaml
+containers:
+  - securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+      requests:
+        memory: "256Mi"
+        cpu: "200m"
+```
+See the docs for [`securityContext` key here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) and [`resources` key here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+
 An example podconfig.yaml would be:
 
 ```yaml
 apiVersion: v1
-kind: PodSpec
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -157,8 +176,16 @@ affinity:
 imagePullSecrets:
   - name: secret1
   - name: privatepullsecret
+containers:
+  - securityContext:
+      runAsUser: 1000
+    resources:
+      limits:
+        cpu: "1"
+        memory: "512Mi"
+
 ```
-This would have an affinity for any cluster node tagged with `scandallowed: true` and would attempt to use the k8s secrets `secret1` or `privatepullsecret` to pull `SCAND_IMAGE` from your private container registry.
+This would have an affinity for any cluster node tagged with `scandallowed: true` and would attempt to use the k8s secrets `secret1` or `privatepullsecret` to pull `SCAND_IMAGE` from your private container registry.  This would also specify resource limits and associated securityContexts.
 
 Typically the podconfig yaml file should be supplied via a config map and mounted inside Scan Jobs Manager container and path to it supplied through `args`: 
 

--- a/k8sclient.go
+++ b/k8sclient.go
@@ -87,13 +87,12 @@ func getk8sJob(job Job) *batchv1.Job {
 		} else {
 			log.Println("Warning: podconfig has no ImagePullSecrets.")
 		}
-		if copy.Containers != nil {
-			if len(copy.Containers) > 0 {
-				result.Spec.Template.Spec.Containers[0].SecurityContext = copy.Containers[0].SecurityContext
-				result.Spec.Template.Spec.Containers[0].Resources = copy.Containers[0].Resources
-			} else {
-				log.Println("Warning: podconfig has empty Containers.")
-			}
+
+		if copy.Containers != nil && len(copy.Containers) > 0 {
+			result.Spec.Template.Spec.Containers[0].SecurityContext = copy.Containers[0].SecurityContext
+			result.Spec.Template.Spec.Containers[0].Resources = copy.Containers[0].Resources
+		} else {
+			log.Println("Warning: podconfig has empty Containers.")
 		}
 	}
 	return result

--- a/k8sclient.go
+++ b/k8sclient.go
@@ -73,12 +73,6 @@ func getk8sJob(job Job) *batchv1.Job {
 		},
 	}
 
-	// Merge securityContext and resources from podconfig only if it's defined
-	if podconfig != nil && len(podconfig.Containers) > 0 {
-		result.Spec.Template.Spec.Containers[0].SecurityContext = podconfig.Containers[0].SecurityContext
-		result.Spec.Template.Spec.Containers[0].Resources = podconfig.Containers[0].Resources
-	}
-
 	if podconfig != nil {
 		copy := podconfig.DeepCopy()
 
@@ -92,6 +86,14 @@ func getk8sJob(job Job) *batchv1.Job {
 			result.Spec.Template.Spec.ImagePullSecrets = copy.ImagePullSecrets
 		} else {
 			log.Println("Warning: podconfig has no ImagePullSecrets.")
+		}
+		if copy.Containers != nil {
+			if len(copy.Containers) > 0 {
+				result.Spec.Template.Spec.Containers[0].SecurityContext = copy.Containers[0].SecurityContext
+				result.Spec.Template.Spec.Containers[0].Resources = copy.Containers[0].Resources
+			} else {
+				log.Println("Warning: podconfig has empty Containers.")
+			}
 		}
 	}
 	return result

--- a/k8sclient.go
+++ b/k8sclient.go
@@ -72,6 +72,13 @@ func getk8sJob(job Job) *batchv1.Job {
 			TTLSecondsAfterFinished: &tTLSecondsAfterFinished,
 		},
 	}
+
+	// Merge securityContext and resources from podconfig only if it's defined
+	if podconfig != nil && len(podconfig.Containers) > 0 {
+		result.Spec.Template.Spec.Containers[0].SecurityContext = podconfig.Containers[0].SecurityContext
+		result.Spec.Template.Spec.Containers[0].Resources = podconfig.Containers[0].Resources
+	}
+
 	if podconfig != nil {
 		copy := podconfig.DeepCopy()
 

--- a/podconfig.go
+++ b/podconfig.go
@@ -44,7 +44,12 @@ func readPodConfig(filename string) {
 		log.Printf("ImagePullSecrets: %+v\n", podconfig.ImagePullSecrets)
 	}
 
-	if podconfig.Affinity == nil && len(podconfig.ImagePullSecrets) == 0 {
-		log.Printf("Neither Affinity nor ImagePullSecrets could be found in %s.", filename)
+	// Check if containers are defined, and if so, print the values
+	if len(podconfig.Containers) > 0 {
+		log.Printf("Container Configurations: %+v\n", podconfig.Containers)
+	}
+
+	if podconfig.Affinity == nil && len(podconfig.ImagePullSecrets) == 0 && len(podconfig.Containers) == 0 {
+		log.Printf("Neither Affinity, ImagePullSecrets, nor Container Configurations could be found in %s.", filename)
 	}
 }


### PR DESCRIPTION
Adding the ability to specify scand-agent resources and securityContexts via podconfig input file.  
the input file format for podconfig will now have an additional context of 'container' as so:
```
containers:
  - securityContext:
      runAsUser: 1000
    resources:
      limits:
        cpu: "1"
        memory: "512Mi"
```
This allows the end user to specify securityContext as well as resource limits on the launched scand-agent containers