### PR TITLE
Updating dockerfile to use scanduser instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ RUN go mod download -x
 RUN CGO_ENABLED=0 GOOS=linux go build -o scand-manager .
 
 FROM busybox
+# Create a non-root user and group with UID/GID 1000
+RUN adduser -D -u 1001 scanduser
 COPY --from=builder /app/scand-manager /bin/
+USER scanduser
+
 EXPOSE 8090
 ENTRYPOINT ["/bin/scand-manager"]
-


### PR DESCRIPTION
We should build our docker container to run as non-root, creating a scanduser account and using it instead