### PR TITLE
Job proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.42c
+.DS_Store
+.dccache

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ spec:
               value: http://api-proxy.example:8080
             - name: HTTPS_PROXY_API
               value: http://api-proxy.example:8443
+            - name: NO_PROXY
+              value: "example.com,192.168.1.0/24"
+            - name: NO_PROXY_API
+              value: "example.com,192.168.1.0/24"
       imagePullSecrets:
           # Pull secret for scand-manager container, if required
           # NOT for scand-agent jobs, that should be in podconfig.yaml
@@ -144,7 +148,8 @@ spec:
 | `PLATFORM_SERVICE` | The hostname and port for that Conformance Scan uses to connect to 42Crunch Platform. The default hostname for most users is `services.us.42crunch.cloud:8001`.                                                                                                                                                |
 | `SCAND_IMAGE`      | The version of the Docker image `scand-agent` that the service pulls and runs for the on-premises scan. The default is `42crunch/scand-agent:latest`. For more details on the available images, see the [release notes of 42Crunch Platform](https://docs.42crunch.com/latest/content/whatsnew/whats_new.htm). |
 | `EXPIRATION_TIME`  | The expiration time for the jobs (in seconds). Completed jobs are deleted after the specified time. The default value is `86400` (24 hours). Requires Kubernetes v1.21 or newer, for older Kubernetes versions jobs must be cleaned up manually using provided API or `kubectl`.                               |
-| `HTTP(S)_PROXY(_API)`| Here you can specify `HTTP_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY_API`, and/or `HTTPS_PROXY_API` as the default values for these environmental runtime variables.  These can be changed at runtime in the job submission env as well. |
+| `HTTP(S)_PROXY(_API)`| Here you can specify `HTTP_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY_API`, and/or `HTTPS_PROXY_API` default values for these environmental runtime variables.  These can be changed at runtime in the job submission env as well. |
+| `NO_PROXY(_API)`| Here you can specify `NO_PROXY`, and/or `NO_PROXY_API` default values for these environmental runtime variables.  These can be changed at runtime in the job submission env as well.  This will force these particular hosts to not use the defined `HTTP(S)_PROXY(_API)` |
 
 ### Healthcheck
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,19 @@ spec:
               value: 42crunch/scand-agent:latest
             - name: EXPIRATION_TIME
               value: "86400"
+            # Example proxy settings that can be overridden as needed during job creation. 
+            # These will be passed to scand-agent jobs by default if specified
+            - name: HTTP_PROXY
+              value: http://corp-proxy.example:8080
+            - name: HTTPS_PROXY
+              value: http://corp-proxy.example:8443
+            - name: HTTP_PROXY_API
+              value: http://api-proxy.example:8080
+            - name: HTTPS_PROXY_API
+              value: http://api-proxy.example:8443
       imagePullSecrets:
-      	  # Pull secret for scand-manager container, if required
-      	  # NOT for scand-agent jobs, that should be in podconfig.yaml
+          # Pull secret for scand-manager container, if required
+          # NOT for scand-agent jobs, that should be in podconfig.yaml
   		  - name: privatepullsecret 
 ---
 # service
@@ -134,6 +144,7 @@ spec:
 | `PLATFORM_SERVICE` | The hostname and port for that Conformance Scan uses to connect to 42Crunch Platform. The default hostname for most users is `services.us.42crunch.cloud:8001`.                                                                                                                                                |
 | `SCAND_IMAGE`      | The version of the Docker image `scand-agent` that the service pulls and runs for the on-premises scan. The default is `42crunch/scand-agent:latest`. For more details on the available images, see the [release notes of 42Crunch Platform](https://docs.42crunch.com/latest/content/whatsnew/whats_new.htm). |
 | `EXPIRATION_TIME`  | The expiration time for the jobs (in seconds). Completed jobs are deleted after the specified time. The default value is `86400` (24 hours). Requires Kubernetes v1.21 or newer, for older Kubernetes versions jobs must be cleaned up manually using provided API or `kubectl`.                               |
+| `HTTP(S)_PROXY(_API)`| Here you can specify `HTTP_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY_API`, and/or `HTTPS_PROXY_API` as the default values for these environmental runtime variables.  These can be changed at runtime in the job submission env as well. |
 
 ### Healthcheck
 

--- a/charts/scand-manager/job-manager-config.yaml
+++ b/charts/scand-manager/job-manager-config.yaml
@@ -95,8 +95,8 @@ spec:
             - name: HTTPS_PROXY_API
               value: http://api-proxy.example:8443
       imagePullSecrets:
-      	  # Pull secret for scand-manager container, if required
-      	  # NOT for scand-agent jobs, that should be in podconfig.yaml
+          # Pull secret for scand-manager container, if required
+          # NOT for scand-agent jobs, that should be in podconfig.yaml
         - name: privatepullsecret 
 ---
 # service

--- a/charts/scand-manager/job-manager-config.yaml
+++ b/charts/scand-manager/job-manager-config.yaml
@@ -94,6 +94,10 @@ spec:
               value: http://api-proxy.example:8080
             - name: HTTPS_PROXY_API
               value: http://api-proxy.example:8443
+            - name: NO_PROXY
+              value: "example.com,192.168.1.0/24"
+            - name: NO_PROXY_API
+              value: "example.com,192.168.1.0/24"
       imagePullSecrets:
           # Pull secret for scand-manager container, if required
           # NOT for scand-agent jobs, that should be in podconfig.yaml

--- a/charts/scand-manager/job-manager-config.yaml
+++ b/charts/scand-manager/job-manager-config.yaml
@@ -1,0 +1,113 @@
+# service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-sa
+---
+# role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: api-role
+rules:
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "create", "delete", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+# role binding
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: api-sa-rolebinding
+  labels:
+    app: tools-rbac
+subjects:
+  - kind: ServiceAccount
+    name: api-sa
+roleRef:
+  kind: Role
+  name: api-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+  name: scand-job-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scand-job-manager
+  template:
+    metadata:
+      labels:
+        app: scand-job-manager
+    spec:
+      serviceAccountName: api-sa
+      containers:
+        - image: 42crunch/scand-manager:v1
+          name: scand-job-manager
+          ports:
+            - containerPort: 8090
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8090
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PLATFORM_SERVICE
+              value: services.us.42crunch.cloud:8001
+            - name: SCAND_IMAGE
+              value: 42crunch/scand-agent:latest
+            - name: EXPIRATION_TIME
+              value: "86400"
+            # Example proxy settings that can be overridden as needed during job creation. 
+            # These will be passed to scand-agent jobs by default if specified
+            - name: HTTP_PROXY
+              value: http://corp-proxy.example:8080
+            - name: HTTPS_PROXY
+              value: http://corp-proxy.example:8443
+            - name: HTTP_PROXY_API
+              value: http://api-proxy.example:8080
+            - name: HTTPS_PROXY_API
+              value: http://api-proxy.example:8443
+      imagePullSecrets:
+      	  # Pull secret for scand-manager container, if required
+      	  # NOT for scand-agent jobs, that should be in podconfig.yaml
+        - name: privatepullsecret 
+---
+# service
+apiVersion: v1
+kind: Service
+metadata:
+  name: scand-job-manager
+spec:
+  type: NodePort
+  ports:
+    - port: 8090
+      targetPort: 8090
+  selector:
+    app: scand-job-manager

--- a/charts/scand-manager/templates/deployment.yaml
+++ b/charts/scand-manager/templates/deployment.yaml
@@ -68,6 +68,15 @@ spec:
               value: {{ .Values.scanJob.scandImage }}
             - name: EXPIRATION_TIME
               value: {{ .Values.scanJob.expirationTime | quote }}
+            # Default proxies for launched scand-agent jobs
+            - name: HTTP_PROXY
+              value: {{ .Values.scanJob.proxy.httpProxy | quote }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.scanJob.proxy.httpsProxy | quote }}
+            - name: HTTP_PROXY_API
+              value: {{ .Values.scanJob.proxy.httpProxyApi | quote }}
+            - name: HTTPS_PROXY_API
+              value: {{ .Values.scanJob.proxy.httpsProxyApi | quote }}
           {{- if .Values.scanJob.podConfig.enabled }}
           volumeMounts:
             - name: config

--- a/charts/scand-manager/values.yaml
+++ b/charts/scand-manager/values.yaml
@@ -12,7 +12,7 @@ containerPort: 8090
 #
 scanJob:
   platformService: services.42crunch.com:8001
-  scandImage: 42crunch/scand-agent:v2
+  scandImage: 42crunch/scand-agent:latest
   expirationTime: 3600
   ## Proxy defaults for API Scan jobs
   ## E.g.:

--- a/charts/scand-manager/values.yaml
+++ b/charts/scand-manager/values.yaml
@@ -8,12 +8,24 @@ image:
 containerPort: 8090
 
 ## Parameters for on-premises conformance scan Job
-## ref: https://docs.42crunch.com/latest/content/tasks/scan_api_conformance.htm
+## ref: https://docs.42crunch.com/latest/content/tasks/scan_api_conformance_v2.htm
 #
 scanJob:
   platformService: services.42crunch.com:8001
-  scandImage: 42crunch/scand-agent:latest
+  scandImage: 42crunch/scand-agent:v2
   expirationTime: 3600
+  ## Proxy defaults for API Scan jobs
+  ## E.g.:
+  ## proxy:
+  ##   httpProxy: "http://proxy.example.com:8080"
+  ##   httpsProxy: "https://proxy.example.com:8080"
+  ##   httpProxyApi: "http://proxy.example.com:8080"
+  ##   httpsProxyApi: "https://proxy.example.com:8080"
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    httpProxyApi: ""
+    httpsProxyApi: ""
   ## PodConfig for conformance scan Job
   ## Currently only support Pod Affinity rule
   ## ref: https://github.com/42Crunch/scand-manager/tree/master#optionally-configure-pod-affinity-rules

--- a/charts/scand-manager/values.yaml
+++ b/charts/scand-manager/values.yaml
@@ -21,11 +21,15 @@ scanJob:
   ##   httpsProxy: "https://proxy.example.com:8080"
   ##   httpProxyApi: "http://proxy.example.com:8080"
   ##   httpsProxyApi: "https://proxy.example.com:8080"
+  ##   noProxy: "example.com,192.168.1.0/24"
+  ##   noProxyApi: "example.com,192.168.1.0/24"
   proxy:
     httpProxy: ""
     httpsProxy: ""
     httpProxyApi: ""
     httpsProxyApi: ""
+    noProxy: ""
+    noProxyApi: ""
   ## PodConfig for conformance scan Job
   ## Currently only support Pod Affinity rule
   ## ref: https://github.com/42Crunch/scand-manager/tree/master#optionally-configure-pod-affinity-rules

--- a/config.go
+++ b/config.go
@@ -53,31 +53,35 @@ func readEnvConfig() {
 	httpProxy := os.Getenv("HTTP_PROXY")
 	if httpProxy != "" {
 		defaultHTTPProxy = httpProxy
-	} else {
-		defaultHTTPProxy = os.Getenv("http_proxy")
 	}
 
 	// default HTTPS proxy
 	httpsProxy := os.Getenv("HTTPS_PROXY")
 	if httpsProxy != "" {
 		defaultHTTPSProxy = httpsProxy
-	} else {
-		defaultHTTPSProxy = os.Getenv("https_proxy")
 	}
 
 	// default HTTP proxy for API calls
 	httpProxyAPI := os.Getenv("HTTP_PROXY_API")
 	if httpProxyAPI != "" {
 		defaultHTTPProxyAPI = httpProxyAPI
-	} else {
-		defaultHTTPProxyAPI = os.Getenv("http_proxy_api")
 	}
 
 	// default HTTPS proxy for API calls
 	httpsProxyAPI := os.Getenv("HTTPS_PROXY_API")
 	if httpsProxyAPI != "" {
 		defaultHTTPSProxyAPI = httpsProxyAPI
-	} else {
-		defaultHTTPSProxyAPI = os.Getenv("https_proxy_api")
+	}
+
+	// default NO_PROXY
+	noProxy := os.Getenv("NO_PROXY")
+	if noProxy != "" {
+		defaultNoProxy = noProxy
+	}
+
+	// default NO_PROXY_API
+	noProxyAPI := os.Getenv("NO_PROXY_API")
+	if noProxyAPI != "" {
+		defaultNoProxyAPI = noProxyAPI
 	}
 }

--- a/config.go
+++ b/config.go
@@ -48,4 +48,36 @@ func readEnvConfig() {
 			log.Fatalf("ERROR, invalid EXPIRATION_TIME env var: '%d', must be <= %d", expirationTimeInt, maxExpirationTime)
 		}
 	}
+	// Default proxy envs (optional). Prefer upper-case; fall back to lower-case if set.
+	// default HTTP proxy
+	httpProxy := os.Getenv("HTTP_PROXY")
+	if httpProxy != "" {
+		defaultHTTPProxy = httpProxy
+	} else {
+		defaultHTTPProxy = os.Getenv("http_proxy")
+	}
+
+	// default HTTPS proxy
+	httpsProxy := os.Getenv("HTTPS_PROXY")
+	if httpsProxy != "" {
+		defaultHTTPSProxy = httpsProxy
+	} else {
+		defaultHTTPSProxy = os.Getenv("https_proxy")
+	}
+
+	// default HTTP proxy for API calls
+	httpProxyAPI := os.Getenv("HTTP_PROXY_API")
+	if httpProxyAPI != "" {
+		defaultHTTPProxyAPI = httpProxyAPI
+	} else {
+		defaultHTTPProxyAPI = os.Getenv("http_proxy_api")
+	}
+
+	// default HTTPS proxy for API calls
+	httpsProxyAPI := os.Getenv("HTTPS_PROXY_API")
+	if httpsProxyAPI != "" {
+		defaultHTTPSProxyAPI = httpsProxyAPI
+	} else {
+		defaultHTTPSProxyAPI = os.Getenv("https_proxy_api")
+	}
 }

--- a/data.go
+++ b/data.go
@@ -127,6 +127,8 @@ func readJobRequest(r *http.Request) (*Job, error) {
 	addProxyEnv("HTTPS_PROXY", defaultHTTPSProxy)
 	addProxyEnv("HTTP_PROXY_API", defaultHTTPProxyAPI)
 	addProxyEnv("HTTPS_PROXY_API", defaultHTTPSProxyAPI)
+	addProxyEnv("NO_PROXY", defaultNoProxy)
+	addProxyEnv("NO_PROXY_API", defaultNoProxyAPI)
 
 	// Helper function to set or override an env var in envVars
 	setOrOverrideEnv := func(name, value string) {
@@ -145,13 +147,14 @@ func readJobRequest(r *http.Request) (*Job, error) {
 			if strings.HasPrefix(nameUpper, "SECURITY_") ||
 				strings.HasPrefix(nameUpper, "SCAN42C_") ||
 				strings.HasPrefix(nameUpper, "HTTPS_") ||
-				strings.HasPrefix(nameUpper, "HTTP_") {
+				strings.HasPrefix(nameUpper, "HTTP_") ||
+				strings.HasPrefix(nameUpper, "NO_PROXY") {
 
 				// Per-job override (or addition)
 				setOrOverrideEnv(name, value)
 			} else {
-				log.Println("ERROR, invalid env variable in the request, must start with 'SECURITY_, SCAN42C_, or HTTP(S)_' ", name)
-				return nil, errors.New("invalid environment variable name, must start with 'SECURITY_, SCAN42C_, or HTTP(S)_'")
+				log.Println("ERROR, invalid env variable in the request, must start with 'SECURITY_, SCAN42C_, NO_PROXY, or HTTP(S)_' ", name)
+				return nil, errors.New("invalid environment variable name, must start with 'SECURITY_, SCAN42C_, NO_PROXY, or HTTP(S)_'")
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ var defaultHTTPProxy string
 var defaultHTTPSProxy string
 var defaultHTTPProxyAPI string
 var defaultHTTPSProxyAPI string
+var defaultNoProxy string
+var defaultNoProxyAPI string
 
 func main() {
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,12 @@ var expirationTimeInt int64
 var clientset *kubernetes.Clientset
 var podconfig *v1.PodSpec
 
+// default proxies for jobs
+var defaultHTTPProxy string
+var defaultHTTPSProxy string
+var defaultHTTPProxyAPI string
+var defaultHTTPSProxyAPI string
+
 func main() {
 
 	podconfigFile := flag.String("podconfig", "", "pod configuration file")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,6 +54,10 @@ paths:
                   platformService: protection.dev.42crunch.com:8001
                   scandImage: 42crunch/scand-agent:latest
                   env:
+                    HTTP_PROXY: http://proxy.example.com:8080
+                    HTTPS_PROXY: http://proxy.example.com:8080
+                    HTTP_PROXY_API: http://proxy-api.example.com:8080
+                    HTTPS_PROXY_API: http://proxy-api.example.com:8080
                     SECURITY_FOO: bar
                     SECURITY_BAZ: bam
             schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -206,8 +206,8 @@ components:
         token:
           description: On-premises scan token
           type: string
-          pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
-          maxLength: 36
+          pattern: "^(scan_)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          maxLength: 41
           minLength: 36
         name:
           $ref: "#/components/schemas/JobName"
@@ -215,28 +215,33 @@ components:
           description: Expiration time for a job (in seconds)
           type: integer
           maximum: 604800
-          minimum: 0
+          minimum: 1
           format: int32
         platformService:
           description: Hostname and port for connecting to 42 Crunch Platform
           type: string
-          pattern: ^\P{Cc}+$
+          pattern: "^[^:]+:[0-9]{3,5}$"
           maxLength: 128
           minLength: 3
         scandImage:
           description: Docker image for scand-agent
           type: string
-          pattern: ^\P{Cc}+$
+          pattern: "^\\P{Cc}{1,128}$"
           maxLength: 128
           minLength: 1
         env:
-          description: Environment variables for scand-agent (must start with 'SECURITY_, SCAN42C_, or set HTTP proxies)
+          description: Environment variables for scand-agent (must start with SECURITY_, SCAN42C_, or HTTP(S)_)
           type: object
           additionalProperties:
             type: string
             pattern: ^\P{Cc}+$
             minLength: 0
             maxLength: 512
+          example:
+            HTTPS_PROXY: http://proxy.example.com:8080
+            HTTPS_PROXY_API: http://proxy-api.example.com:8080
+            SECURITY_FOO: bar
+            SCAN42C_FEATURE_FLAG: enabled
       additionalProperties: false
       required:
         - token

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -58,6 +58,8 @@ paths:
                     HTTPS_PROXY: http://proxy.example.com:8080
                     HTTP_PROXY_API: http://proxy-api.example.com:8080
                     HTTPS_PROXY_API: http://proxy-api.example.com:8080
+                    NO_PROXY: "sitea.com"
+                    NO_PROXY_API: "api.sitea.com"
                     SECURITY_FOO: bar
                     SECURITY_BAZ: bam
             schema:


### PR DESCRIPTION
updated to add the ability to define the default values for proxies [HTTP(S)_PROXY(_API)] for scand-agent created jobs. These can be set by default and overridden as needed.  Also added the ability to specify NO_PROXY(_API)